### PR TITLE
✨ feat: add global cart item count badge to cart icon

### DIFF
--- a/src/components/features/shopping-cart/CartIcon.tsx
+++ b/src/components/features/shopping-cart/CartIcon.tsx
@@ -1,15 +1,23 @@
+'use client';
+
 import { ShoppingCart } from 'lucide-react';
-import { useCart } from '@/components/features/shop/ProductDetail/CartContext';
+import { useCartState } from '@/store/cartStore';
+import { useEffect } from 'react';
 
 export function CartIcon() {
-  const { cartCount } = useCart();
+  const { cartCount, refreshCartCount } = useCartState();
+
+  // 컴포넌트 마운트 시 장바구니 개수 로드
+  useEffect(() => {
+    refreshCartCount();
+  }, [refreshCartCount]);
 
   return (
     <div className="relative">
       <ShoppingCart />
       {cartCount > 0 && (
-        <span className="absolute -top-2 -right-2 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 px-1 text-xs font-bold text-white">
-          {cartCount}
+        <span className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+          {cartCount > 99 ? '99+' : cartCount}
         </span>
       )}
     </div>

--- a/src/components/features/shopping-cart/CartItemCard.tsx
+++ b/src/components/features/shopping-cart/CartItemCard.tsx
@@ -120,7 +120,7 @@ export function CartItemCard({
     }
   };
 
-  //       전체 선택 상태 업데이트**        //
+  //       전체 선택 상태 업데이트        //
   useEffect(() => {
     setLocalChecked(isAllChecked);
   }, [isAllChecked]);

--- a/src/components/features/shopping-cart/CartList.tsx
+++ b/src/components/features/shopping-cart/CartList.tsx
@@ -1,10 +1,6 @@
 //        장바구니에 추가된 상품 목록 렌더링 컴포넌트        //
 import { CartItem } from '@/types/cart';
 import { CartItemCard } from '@/components/features/shopping-cart/CartItemCard';
-// import { useAuthStore } from '@/store/auth.store';
-
-// const API_URL = process.env.NEXT_PUBLIC_API_URL;
-// const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID || '';
 
 interface CartListProps {
   cartItems: CartItem[];
@@ -25,8 +21,6 @@ const CartList: React.FC<CartListProps> = ({
     <div>
       {cartItems.map(item => (
         <div key={item._id} className="mb-0">
-          {/* <Link href={`/shop/${item.product._id}`} prefetch={true}> */}
-          {/* 상품 상세 페이지로 이동 */}
           <CartItemCard
             cartId={item._id}
             id={item.product._id}
@@ -42,7 +36,6 @@ const CartList: React.FC<CartListProps> = ({
             onQuantityChange={onQuantityChange}
             isAllChecked={isAllChecked}
           />
-          {/* </Link> */}
         </div>
       ))}
     </div>

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -1,22 +1,65 @@
 import { create } from 'zustand';
-
-interface CartItem {
-  id: number;
-  name: string;
-  price: number;
-  quantity: number;
-}
+import { fetchCartList } from '@/data/functions/CartFetch.client';
+import { CartItem } from '@/types/cart';
 
 interface CartState {
-  cartItems: CartItem[]; // 장바구니 목록
-  cartCount: number; // 장바구니 아이템 개수
-  setCartItems: (items: CartItem[]) => void; // 장바구니 목록 설정
-  setCartCount: (count: number) => void; // 장바구니 아이템 개수 설정
+  cartItems: CartItem[];
+  cartCount: number;
+  isLoading: boolean;
+
+  // Actions
+  setCartItems: (items: CartItem[]) => void;
+  updateCartCount: () => void;
+  fetchCartData: () => Promise<void>; // API에서 장바구니 데이터 가져오기
+  refreshCartCount: () => Promise<void>; // 장바구니 개수만 새로고침
 }
 
-export const useCartStore = create<CartState>(set => ({
-  cartItems: [], // 초기 장바구니 목록
-  cartCount: 0, // 초기 장바구니 아이템 개수
-  setCartItems: items => set({ cartItems: items }), // 장바구니 목록 업데이트
-  setCartCount: count => set({ cartCount: count }), // 장바구니 아이템 개수 업데이트
+export const useCartState = create<CartState>((set, get) => ({
+  cartItems: [],
+  cartCount: 0,
+  isLoading: false,
+
+  setCartItems: items =>
+    set({
+      cartItems: items,
+      cartCount: items.length,
+    }),
+
+  updateCartCount: () => {
+    const { cartItems } = get();
+    set({ cartCount: cartItems.length });
+  },
+
+  // 전체 장바구니 데이터 가져오기
+  fetchCartData: async () => {
+    set({ isLoading: true });
+    try {
+      const data = await fetchCartList(1, 100);
+      const items = data.item.map(item => ({
+        ...item,
+        isChecked: false,
+        selectedOption: item.selectedOption || '',
+      }));
+
+      set({
+        cartItems: items,
+        cartCount: items.length,
+        isLoading: false,
+      });
+    } catch (error) {
+      console.error('장바구니 데이터 로드 실패:', error);
+      set({ isLoading: false });
+    }
+  },
+
+  // 장바구니 개수만 새로고침
+  refreshCartCount: async () => {
+    try {
+      const data = await fetchCartList(1, 100);
+      set({ cartCount: data.item.length });
+    } catch (error) {
+      console.error('장바구니 개수 조회 실패:', error);
+      set({ cartCount: 0 });
+    }
+  },
 }));


### PR DESCRIPTION
- Display cart item quantity badge across all pages
- Implement real-time cart count updates
- Add visual indicator for cart status

## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정

## PR 체크리스트

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 장바구니에 담긴 상품의 개수를 장바구니 아이콘 위에 배지(badge) 형태로 전역에서 표시하는 기능을 추가
- 사용자가 어느 페이지에 있든 현재 장바구니에 담긴 상품 개수를 한눈에 확인할 수 있도록 하여 UX를 개선

## 이슈

resolves #1 
